### PR TITLE
fix: don't pollute result of any with result of previously failed parsers

### DIFF
--- a/combinator.go
+++ b/combinator.go
@@ -54,7 +54,9 @@ func Any(parsers ...Parserish) Parser {
 		var longestError Error
 		expected := []string{}
 		for _, parser := range parserfied {
-			parser(ps, node)
+			r := newResult(node.Input)
+			parser(ps, r)
+			copyResult(node, r)
 			if ps.Errored() {
 				if ps.Error.pos >= longestError.pos {
 					longestError = ps.Error


### PR DESCRIPTION
Given this scenario:

```go
func runParser(input string, parser Parser) (Result, *State) {
	ps := NewState(input)
	result := Result{}
	parser(ps, &result)
	return result, ps
}

func main() {
	p := Any(
		Seq("abc", "def").Map(func(n *Result) {
			n.Result = "first"
		}),
		Exact("abcdx").Map(func(n *Result) {
			n.Result = "second"
		}))
	res, state := runParser("abcdx", p)
	// res, err := Run(p, "xyz")
	fmt.Println("res::", res.Result)
	fmt.Println("child::", res.Child)
	fmt.Println("token::", res.Token)
	fmt.Println("err::", state.Errored())
}
```

you'd get:

```
res:: second
child:: [abc ]
token:: abcdx
err:: false
```

While it was able to resolve to 'second', `Any()` also kept the `Child` of the first parser (`Seq().Map()` in this case). This PR fixes that and only gives the result of second parser.

Keeping the result of a parser that failed is fine, but overlapping results from two different parsers is not.